### PR TITLE
Allow assigning existing chests as shops

### DIFF
--- a/src/main/java/com/example/foliashop/command/SetShopCommand.java
+++ b/src/main/java/com/example/foliashop/command/SetShopCommand.java
@@ -29,14 +29,22 @@ public class SetShopCommand implements CommandExecutor {
             return true;
         }
         Block target = p.getTargetBlockExact(5);
-        if (target == null || target.getType() != Material.AIR) {
-            plugin.msg().send(p, "not-looking-at-air", Map.of());
+        if (target == null) {
+            plugin.msg().send(p, "shop-invalid-target", Map.of());
             return true;
         }
+        Material type = target.getType();
+        if (type != Material.AIR && type != Material.CHEST) {
+            plugin.msg().send(p, "shop-invalid-target", Map.of());
+            return true;
+        }
+        boolean shouldPlaceChest = type == Material.AIR;
         Location place = target.getLocation();
 
         FoliaSchedulerUtil.runAtLocation(plugin, place, () -> {
-            place.getBlock().setType(Material.CHEST);
+            if (shouldPlaceChest) {
+                place.getBlock().setType(Material.CHEST);
+            }
             ShopPoint sp = new ShopPoint(0, place.getWorld().getName(), place.getBlockX(), place.getBlockY(), place.getBlockZ(),
                     "SHOP", p.getLocation().getYaw(), p.getLocation().getPitch(), p.getUniqueId().toString());
             try {

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,6 +1,7 @@
 prefix: "§7[§aShop§7] "
 no-permission: "{prefix}§c你没有权限。"
 not-looking-at-air: "{prefix}§c目标位置非空气，无法放置箱子。"
+shop-invalid-target: "{prefix}§c目标方块必须是空气或箱子，无法创建商店。"
 shop-placed: "{prefix}§a商店点已创建 §7@ {world} {x} {y} {z}"
 sell-placed: "{prefix}§a回收点已创建 §7@ {world} {x} {y} {z}"
 open-shop: "{prefix}§a已打开商店。"


### PR DESCRIPTION
## Summary
- allow `/setshop` to use an existing chest instead of always requiring air
- add a dedicated message when the looked-at block is not valid for shop creation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e4468697848330bcf40af9ea00982c